### PR TITLE
Add basic app and auth tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,25 @@
+import os
+from flask import Flask
+from src.app import create_app
+
+
+def test_create_app_returns_flask_app():
+    """Verify that create_app returns a configured Flask instance."""
+
+    app = create_app({"TESTING": True})
+    assert isinstance(app, Flask)
+    assert app.config["TESTING"] is True
+    assert app.config["SECRET_KEY"] == os.environ.get("SECRET_KEY")
+
+
+def test_index_route_returns_success():
+    """Ensure the index route responds with the expected payload."""
+
+    app = create_app({"TESTING": True})
+    client = app.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "success",
+        "message": "Codex Web-Native API is running",
+    }

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,0 +1,22 @@
+import importlib
+import types
+
+
+def test_auth_modules_importable():
+    """Confirm that authentication modules can be imported."""
+
+    modules = [
+        "src.auth.user",
+        "src.auth.password",
+        "src.auth.token_management",
+    ]
+    for name in modules:
+        module = importlib.import_module(name)
+        assert isinstance(module, types.ModuleType)
+
+
+def test_auth_init_all_is_list():
+    """Verify that src.auth exposes __all__ as a list."""
+
+    auth = importlib.import_module("src.auth")
+    assert isinstance(auth.__all__, list)


### PR DESCRIPTION
## Summary
- add tests for create_app
- add minimal tests for auth module imports

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*