### PR TITLE
Add integrations config loader and dashboard preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ This repository implements a modern application development workflow optimized f
 4. Run tests with `pytest` to verify everything is working
 5. Ensure the `ai_workflow` package is installed or available on your `PYTHONPATH`.
 6. Set the `SECRET_KEY` environment variable before running the application.
+7. Configure integration credentials using environment variables or a `.env` file.
+
+### Environment Configuration
+
+The `src/config.py` module loads environment variables for external services. You
+can create a `.env` file in the project root containing keys such as:
+
+```bash
+NOTION_API_KEY=your-notion-key
+GITHUB_TOKEN=your-github-token
+SLACK_TOKEN=your-slack-token
+DATABASE_URL=sqlite:///app.db
+```
+
+These values are automatically loaded when the application starts.
 
 ## Development Workflow
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,29 @@
+"""Configuration utilities for server integrations.
+
+This module loads environment variables to configure
+connections for the Model Context Protocol server integrations.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@dataclass
+class IntegrationsConfig:
+    """Configuration values for server integrations."""
+
+    notion_api_key: str = os.getenv("NOTION_API_KEY", "")
+    github_token: str = os.getenv("GITHUB_TOKEN", "")
+    slack_token: str = os.getenv("SLACK_TOKEN", "")
+    database_url: str = os.getenv("DATABASE_URL", "")
+
+
+def load_integrations_config() -> IntegrationsConfig:
+    """Return a populated :class:`IntegrationsConfig` instance."""
+
+    return IntegrationsConfig()

--- a/src/dashboard/PrivDashboardPreview.jsx
+++ b/src/dashboard/PrivDashboardPreview.jsx
@@ -1,0 +1,33 @@
+// Dashboard preview component for the priv system.
+
+import React, { useState } from "react";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  Cell,
+} from "recharts";
+import {
+  Server,
+  Database,
+  GitBranch,
+  Code,
+  AlertCircle,
+  Check,
+  Cpu,
+  Activity,
+  Globe,
+  Command,
+  RefreshCw,
+} from "lucide-react";
+
+// ... rest of component omitted for brevity

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+from src.config import load_integrations_config
+
+
+def test_load_integrations_config(monkeypatch):
+    monkeypatch.setenv("NOTION_API_KEY", "abc")
+    monkeypatch.setenv("GITHUB_TOKEN", "def")
+    monkeypatch.setenv("SLACK_TOKEN", "ghi")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    cfg = load_integrations_config()
+
+    assert cfg.notion_api_key == "abc"
+    assert cfg.github_token == "def"
+    assert cfg.slack_token == "ghi"
+    assert cfg.database_url == "sqlite:///:memory:"


### PR DESCRIPTION
## Summary
- add IntegrationsConfig for environment variables
- document environment configuration in README
- add placeholder React dashboard component
- test environment configuration loading

## Testing
- `black src tests --quiet`
- `flake8 src tests` *(fails: command not found)*
- `prettier -w src/dashboard/PrivDashboardPreview.jsx`
- `eslint src/dashboard/PrivDashboardPreview.jsx` *(fails: no config)*
- `pytest -q` *(fails: command not found)*