### PR TITLE
Fix IntegrationsConfig env loading

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ connections for the Model Context Protocol server integrations.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -17,10 +17,10 @@ load_dotenv()
 class IntegrationsConfig:
     """Configuration values for server integrations."""
 
-    notion_api_key: str = os.getenv("NOTION_API_KEY", "")
-    github_token: str = os.getenv("GITHUB_TOKEN", "")
-    slack_token: str = os.getenv("SLACK_TOKEN", "")
-    database_url: str = os.getenv("DATABASE_URL", "")
+    notion_api_key: str = field(default_factory=lambda: os.getenv("NOTION_API_KEY", ""))
+    github_token: str = field(default_factory=lambda: os.getenv("GITHUB_TOKEN", ""))
+    slack_token: str = field(default_factory=lambda: os.getenv("SLACK_TOKEN", ""))
+    database_url: str = field(default_factory=lambda: os.getenv("DATABASE_URL", ""))
 
 
 def load_integrations_config() -> IntegrationsConfig:


### PR DESCRIPTION
## Summary
- delay env var retrieval for IntegrationsConfig until instantiation

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*