### PR TITLE
Fix registry paths and restore module files

### DIFF
--- a/modules/03_parallel-async.md
+++ b/modules/03_parallel-async.md
@@ -1,0 +1,21 @@
+---
+name: "Module_ParallelAsync"
+version: "1.0"
+description: "Manages parallel task execution and asynchronous offloading in Codex Web-Native environment."
+inputs: ["src/", "tests/"]
+outputs: ["audits/parallel_execution.log.md"]
+dependencies: []
+author: "AI"
+last_updated: "2025-05-20"
+status: "active"
+---
+
+# Parallel Async Execution Module
+
+## Purpose
+
+This module orchestrates multiple AI tasks concurrently while respecting the execution budget. It ensures that asynchronous operations are properly logged and that conflicts are avoided.
+
+## Prompt
+
+Coordinate tasks using the configured parallel strategy and monitor resource usage. Record progress in `audits/parallel_execution.log.md`.

--- a/modules/09_observability.md
+++ b/modules/09_observability.md
@@ -1,0 +1,21 @@
+---
+name: "Module_Observability"
+version: "1.0"
+description: "Monitors and reports performance metrics for Codex Web-Native operations."
+inputs: ["audits/performance/", "src/"]
+outputs: ["audits/performance/"]
+dependencies: []
+author: "AI"
+last_updated: "2025-05-20"
+status: "active"
+---
+
+# Observability Module
+
+## Purpose
+
+Provide observability into AI task performance, recording metrics such as runtime, memory usage, and responsiveness.
+
+## Prompt
+
+Collect metrics during task execution and update the dashboards under `audits/performance/`. Alert when thresholds defined in `execution-budget.yaml` are exceeded.

--- a/modules/10_regression-suite.md
+++ b/modules/10_regression-suite.md
@@ -1,0 +1,21 @@
+---
+name: "Module_RegressionSuite"
+version: "1.0"
+description: "Manages comprehensive regression testing to prevent performance and functional regressions."
+inputs: ["tests/", "src/"]
+outputs: ["tests/"]
+dependencies: []
+author: "AI"
+last_updated: "2025-05-20"
+status: "active"
+---
+
+# Regression Test Suite Module
+
+## Purpose
+
+This module runs and maintains a suite of regression tests to catch regressions in functionality and performance.
+
+## Prompt
+
+Execute the full regression test suite using `pytest`. Ensure coverage meets the target specified in `execution-budget.yaml` and report results.

--- a/modules/11_diff-analyzer.md
+++ b/modules/11_diff-analyzer.md
@@ -1,0 +1,21 @@
+---
+name: "Module_DiffAnalyzerV2"
+version: "1.0"
+description: "Analyzes code changes to ensure coherence marker compliance and perform semantic diff verification."
+inputs: ["audits/diffs/"]
+outputs: ["audits/diffs/"]
+dependencies: []
+author: "AI"
+last_updated: "2025-05-20"
+status: "active"
+---
+
+# Diff Analyzer V2 Module
+
+## Purpose
+
+Provide enhanced analysis of code diffs to verify coherence marker compliance and highlight semantic changes.
+
+## Prompt
+
+Analyze provided diffs, ensure commit messages match the changes, and record findings in the audits directory.

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -40,7 +40,7 @@ modules:
     marker: chore
 
   - name: Module_ParallelAsync
-    file: ../modules/03_parallel-async.md
+    file: modules/03_parallel-async.md
     version: 1.0
     description: Manages parallel task execution and asynchronous offloading in Codex Web-Native environment.
     status: active
@@ -48,7 +48,7 @@ modules:
     marker: chore
 
   - name: Module_Observability
-    file: ../modules/09_observability.md
+    file: modules/09_observability.md
     version: 1.0
     description: Monitors and reports performance metrics for Codex Web-Native operations.
     status: active
@@ -56,7 +56,7 @@ modules:
     marker: chore
 
   - name: Module_RegressionSuite
-    file: ../modules/10_regression-suite.md
+    file: modules/10_regression-suite.md
     version: 1.0
     description: Manages comprehensive regression testing to prevent performance and functional regressions.
     status: active
@@ -64,7 +64,7 @@ modules:
     marker: test
 
   - name: Module_DiffAnalyzerV2
-    file: ../modules/11_diff-analyzer.md
+    file: modules/11_diff-analyzer.md
     version: 1.0
     description: Analyzes code changes to ensure coherence marker compliance and perform semantic diff verification.
     status: active


### PR DESCRIPTION
## Summary
- update module paths in `prompt-registry.yaml`
- add missing module docs for parallel execution, observability, regression suite, and diff analysis

## Testing
- `black .`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*