### PR TITLE
[feat] add threaded parallel orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ For parallel execution of tasks, use the ParallelFeatureDevCycle chain:
 ```
 
 This utilizes the Module_ParallelAsync to coordinate multiple tasks running concurrently.
+The workflow orchestrator reads `execution-budget.yaml` to determine the
+maximum number of parallel threads and spawns them using a lightweight
+scheduler.
 
 ### Analyzing Diffs
 

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -13,3 +13,9 @@
 - Cached valid markers during diff analyzer initialization
 - Batched line writing in context graph export for improved I/O
 - Expanded documentation with NLU pipeline instructions and audit directory details
+
+## 2025-05-21
+- Implemented threaded execution in `WorkflowOrchestrator` for true parallel task
+  orchestration.
+- Added test coverage for the parallel chain and documented the new scheduler in
+  the README.

--- a/src/ai_workflow/orchestrator.py
+++ b/src/ai_workflow/orchestrator.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+import yaml
+from concurrent.futures import ThreadPoolExecutor
 
 from .context_graphs import ContextGraphManager
 
@@ -16,8 +19,25 @@ class WorkflowOrchestrator:
     capturing a minimal context graph.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, registry_path: str = "prompt-registry.yaml") -> None:
+        """Initialize the orchestrator with registry and budget data."""
+
         self._graph_manager = ContextGraphManager()
+
+        try:
+            with open(registry_path, "r", encoding="utf-8") as f:
+                self._registry = yaml.safe_load(f)
+        except OSError:
+            self._registry = {}
+
+        try:
+            with open("execution-budget.yaml", "r", encoding="utf-8") as f:
+                budget = yaml.safe_load(f)
+            self._max_parallel = budget.get("task_limits", {}).get(
+                "max_parallel_tasks", 3
+            )
+        except OSError:
+            self._max_parallel = 3
 
     def execute_chain(
         self, chain_name: str, context: Dict[str, Any] | None = None
@@ -37,10 +57,45 @@ class WorkflowOrchestrator:
             Execution metadata.
         """
 
-        data: Dict[str, Any] = {
+        chain_def = None
+        for chain in self._registry.get("dependencies", []):
+            if chain.get("chain") == chain_name:
+                chain_def = chain
+                break
+
+        if not chain_def:
+            data = {
+                "chain": chain_name,
+                "context": context or {},
+                "status": "executed",
+            }
+            self._graph_manager.update_from_runtime(data)
+            return data
+
+        sequence = chain_def.get("sequence", [])
+        executed: List[Dict[str, Any]] = []
+        i = 0
+        while i < len(sequence):
+            step = sequence[i]
+            if isinstance(step, dict) and "Module_ParallelAsync" in step:
+                modules = step["Module_ParallelAsync"].get("run_parallel", [])
+                executed.extend(self._run_parallel(modules, context))
+                i += 1
+                continue
+
+            if step == "Module_ParallelAsync":
+                modules = sequence[i + 1 : i + 1 + self._max_parallel]
+                executed.extend(self._run_parallel(modules, context))
+                i += 1 + len(modules)
+                continue
+
+            executed.append(self.execute_module(step, context))
+            i += 1
+
+        data = {
             "chain": chain_name,
-            "context": context or {},
-            "status": "executed",
+            "executed": [m.get("module") for m in executed],
+            "status": "completed",
         }
         self._graph_manager.update_from_runtime(data)
         return data
@@ -57,6 +112,18 @@ class WorkflowOrchestrator:
         }
         self._graph_manager.update_from_runtime(data)
         return data
+
+    def _run_parallel(
+        self, modules: List[str], context: Dict[str, Any] | None = None
+    ) -> List[Dict[str, Any]]:
+        """Execute multiple modules in parallel threads."""
+
+        max_workers = min(len(modules), self._max_parallel)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [
+                executor.submit(self.execute_module, m, context) for m in modules
+            ]
+            return [f.result() for f in futures]
 
     def export_context_graph(self, output_dir: str = "audits/dashboards") -> str:
         """Export the context graph and return the file path."""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -15,6 +15,19 @@ def test_orchestrator_execute_chain(tmp_path):
     assert os.path.exists(path)
 
 
+def test_parallel_chain(tmp_path):
+    orch = WorkflowOrchestrator()
+    result = orch.execute_chain("ParallelFeatureDevCycle", {"foo": "bar"})
+    assert result["status"] == "completed"
+    for mod in [
+        "Module_TaskA",
+        "Module_TestGenerator",
+        "Module_DocWriter",
+        "Module_DiffAnalyzerV2",
+    ]:
+        assert mod in result["executed"]
+
+
 def test_context_graph_manager(tmp_path):
     manager = ContextGraphManager()
     manager.update_from_runtime({"a": 1})


### PR DESCRIPTION
## Summary
- run multiple modules at once using `ThreadPoolExecutor`
- note threaded scheduler in README
- cover new parallel chain behaviour in tests
- log the enhancement in history

## Testing
- `flake8 src/ai_workflow/orchestrator.py tests/test_workflow.py` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*