### PR TITLE
Improve workflow orchestrator

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,8 +9,9 @@ from ai_workflow import (
 
 def test_orchestrator_execute_chain(tmp_path):
     orch = WorkflowOrchestrator()
-    result = orch.execute_chain("demo", {"foo": "bar"})
-    assert result["status"] == "executed"
+    result = orch.execute_chain("DocumentationUpdate", {"foo": "bar"})
+    assert result["status"] == "completed"
+    assert "Module_DocWriter" in result["modules"]
     path = orch.export_context_graph(output_dir=tmp_path.as_posix())
     assert os.path.exists(path)
 


### PR DESCRIPTION
## Summary
- implement sequential module orchestration in `WorkflowOrchestrator`
- load registry for chains and execute modules sequentially
- update workflow unit test to use real chain

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*