### PR TITLE
Implement parallel executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ For parallel execution of tasks, use the ParallelFeatureDevCycle chain:
 ```
 
 This utilizes the Module_ParallelAsync to coordinate multiple tasks running concurrently.
+The underlying implementation uses the ``ParallelExecutor`` class to spawn
+threads for each module, respecting the ``max_parallel_tasks`` setting in
+``execution-budget.yaml``.
 
 ### Analyzing Diffs
 

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -13,3 +13,7 @@
 - Cached valid markers during diff analyzer initialization
 - Batched line writing in context graph export for improved I/O
 - Expanded documentation with NLU pipeline instructions and audit directory details
+
+## 2025-05-21
+- Added ``ParallelExecutor`` for true parallel task orchestration
+- Documented usage in README

--- a/src/ai_workflow/__init__.py
+++ b/src/ai_workflow/__init__.py
@@ -4,10 +4,12 @@ from .context_graphs import ContextGraphManager
 from .orchestrator import WorkflowOrchestrator
 from .performance_monitor import PerformanceMonitor
 from .semantic_diff import SemanticDiffAnalyzer
+from .parallel_executor import ParallelExecutor
 
 __all__ = [
     "WorkflowOrchestrator",
     "ContextGraphManager",
     "SemanticDiffAnalyzer",
     "PerformanceMonitor",
+    "ParallelExecutor",
 ]

--- a/src/ai_workflow/parallel_executor.py
+++ b/src/ai_workflow/parallel_executor.py
@@ -1,0 +1,57 @@
+"""Parallel task execution utilities."""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import Any, Dict, Iterable, List
+
+import yaml
+
+from .orchestrator import WorkflowOrchestrator
+
+
+class ParallelExecutor:
+    """Execute multiple workflow modules concurrently."""
+
+    def __init__(
+        self, max_tasks: int | None = None, log_path: str | None = None
+    ) -> None:
+        with open("execution-budget.yaml", "r", encoding="utf-8") as f:
+            budget = yaml.safe_load(f)
+        default_tasks = budget.get("task_limits", {}).get("max_parallel_tasks", 1)
+        self.max_tasks = max_tasks or default_tasks
+        self.log_path = log_path or os.path.join("audits", "parallel_execution.log.md")
+
+    def _run_module(
+        self, module: str, context: Dict[str, Any] | None
+    ) -> Dict[str, Any]:
+        orch = WorkflowOrchestrator()
+        return orch.execute_module(module, context)
+
+    def run_tasks(
+        self, modules: Iterable[str], context: Dict[str, Any] | None = None
+    ) -> List[Dict[str, Any]]:
+        """Run modules concurrently and return execution results."""
+
+        results: List[Dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=self.max_tasks) as executor:
+            futures = {
+                executor.submit(self._run_module, m, context): m for m in modules
+            }
+            for future in as_completed(futures):
+                results.append(future.result())
+        self._log_results(modules, results)
+        return results
+
+    def _log_results(
+        self, modules: Iterable[str], results: List[Dict[str, Any]]
+    ) -> None:
+        os.makedirs(os.path.dirname(self.log_path), exist_ok=True)
+        with open(self.log_path, "a", encoding="utf-8") as f:
+            f.write(f"## Execution {datetime.now().isoformat()}\n")
+            for module, result in zip(modules, results):
+                status = result.get("status", "unknown")
+                f.write(f"- {module}: {status}\n")
+            f.write("\n")

--- a/tests/test_parallel_executor.py
+++ b/tests/test_parallel_executor.py
@@ -1,0 +1,11 @@
+from ai_workflow import ParallelExecutor
+
+
+def test_parallel_executor_runs_tasks(tmp_path):
+    executor = ParallelExecutor(max_tasks=2, log_path=tmp_path / "log.md")
+    modules = ["Module_TaskA", "Module_TestGenerator", "Module_DocWriter"]
+    results = executor.run_tasks(modules, {"foo": "bar"})
+    assert len(results) == len(modules)
+    for r in results:
+        assert r["status"] == "executed"
+    assert (tmp_path / "log.md").exists()


### PR DESCRIPTION
## Summary
- add `ParallelExecutor` to execute workflow modules concurrently
- export new executor in ai_workflow package
- test the new parallel executor
- document parallelism in README
- record addition in history log

## Testing
- `black src/ tests/ -q`
- `flake8 src/ tests/` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*