### PR TITLE
Integrate regression suite runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ To update performance metrics and generate dashboards:
 ./scripts/ai_workflow_cli.py monitor-performance --generate-dashboard
 ```
 
+### Running the Regression Suite
+
+To execute the full regression test suite and verify that existing features
+remain intact:
+
+```bash
+./scripts/ai_workflow_cli.py run-regression --tests-path tests
+```
+
 ### Visualizing Context Graphs
 
 To visualize the relationships between modules and their input/output contexts:

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -13,3 +13,6 @@
 - Cached valid markers during diff analyzer initialization
 - Batched line writing in context graph export for improved I/O
 - Expanded documentation with NLU pipeline instructions and audit directory details
+
+## 2025-05-21
+- Added RegressionSuiteRunner for automated regression testing and CLI integration.

--- a/modules/10_regression-suite.md
+++ b/modules/10_regression-suite.md
@@ -1,6 +1,6 @@
 ---
 name: "Module_RegressionSuite"
-version: "1.0"
+version: "1.1"
 description: "Manages comprehensive regression testing to prevent performance and functional regressions."
 inputs: ["tests/", "src/"]
 outputs: ["tests/"]
@@ -18,4 +18,4 @@ This module runs and maintains a suite of regression tests to catch regressions 
 
 ## Prompt
 
-Execute the full regression test suite using `pytest`. Ensure coverage meets the target specified in `execution-budget.yaml` and report results.
+Execute the full regression test suite using `pytest`. Parse the output to determine success or failure and return the summary. If any tests fail, trigger the appropriate fix cycle before proceeding. Integrate with Observability and DiffAnalyzer modules to run automatically after risky changes or major refactors.

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -57,7 +57,7 @@ modules:
 
   - name: Module_RegressionSuite
     file: modules/10_regression-suite.md
-    version: 1.0
+    version: 1.1
     description: Manages comprehensive regression testing to prevent performance and functional regressions.
     status: active
     last_update: "2025-05-20"

--- a/scripts/ai_workflow_cli.py
+++ b/scripts/ai_workflow_cli.py
@@ -24,6 +24,7 @@ try:
         ContextGraphManager,
         SemanticDiffAnalyzer,
         PerformanceMonitor,
+        RegressionSuiteRunner,
     )
 except ImportError:
     print(
@@ -216,6 +217,20 @@ def monitor_performance(args):
             print(f"- {file_path}")
 
 
+def run_regression(args):
+    """Run the regression test suite and report results."""
+
+    runner = RegressionSuiteRunner(args.tests_path)
+    results = runner.run()
+    print(results["output"])
+
+    if results["returncode"] == 0:
+        print("\n✅ Regression suite passed")
+    else:
+        print("\n❌ Regression suite failed")
+        sys.exit(results["returncode"])
+
+
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(description="AI Workflow CLI Utility")
@@ -295,6 +310,14 @@ def main():
         help="Generate performance dashboard",
     )
 
+    # Run regression command
+    regression_parser = subparsers.add_parser(
+        "run-regression", help="Execute the regression test suite"
+    )
+    regression_parser.add_argument(
+        "--tests-path", default="tests", help="Path to the tests directory"
+    )
+
     args = parser.parse_args()
 
     # Execute the appropriate command
@@ -308,6 +331,8 @@ def main():
         visualize_context(args)
     elif args.command == "monitor-performance":
         monitor_performance(args)
+    elif args.command == "run-regression":
+        run_regression(args)
     else:
         parser.print_help()
 

--- a/src/ai_workflow/__init__.py
+++ b/src/ai_workflow/__init__.py
@@ -4,10 +4,12 @@ from .context_graphs import ContextGraphManager
 from .orchestrator import WorkflowOrchestrator
 from .performance_monitor import PerformanceMonitor
 from .semantic_diff import SemanticDiffAnalyzer
+from .regression_suite import RegressionSuiteRunner
 
 __all__ = [
     "WorkflowOrchestrator",
     "ContextGraphManager",
     "SemanticDiffAnalyzer",
     "PerformanceMonitor",
+    "RegressionSuiteRunner",
 ]

--- a/src/ai_workflow/regression_suite.py
+++ b/src/ai_workflow/regression_suite.py
@@ -1,0 +1,44 @@
+"""Utilities for running regression tests programmatically."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import Any, Dict
+
+
+class RegressionSuiteRunner:
+    """Run the repository's regression test suite using pytest."""
+
+    def __init__(self, tests_path: str = "tests") -> None:
+        self.tests_path = tests_path
+
+    def run(self) -> Dict[str, Any]:
+        """Execute pytest and return parsed results.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the return code, test summary line and
+            complete pytest output.
+        """
+
+        env = os.environ.copy()
+        command = ["pytest", self.tests_path, "-q"]
+        result = subprocess.run(command, capture_output=True, text=True, env=env)
+        summary_line = self._extract_summary(result.stdout)
+        return {
+            "returncode": result.returncode,
+            "summary": summary_line,
+            "output": result.stdout,
+        }
+
+    @staticmethod
+    def _extract_summary(output: str) -> str:
+        """Return the final summary line from pytest output."""
+
+        for line in reversed(output.splitlines()):
+            if re.search(r"\bpassed\b|\bfailed\b", line):
+                return line.strip()
+        return ""

--- a/tests/test_regression_suite.py
+++ b/tests/test_regression_suite.py
@@ -1,0 +1,14 @@
+from ai_workflow.regression_suite import RegressionSuiteRunner
+
+
+def test_regression_suite_runner(tmp_path):
+    test_dir = tmp_path / "tests"
+    test_dir.mkdir()
+    test_file = test_dir / "test_sample.py"
+    test_file.write_text("def test_ok():\n    assert True\n")
+
+    runner = RegressionSuiteRunner(str(test_dir))
+    result = runner.run()
+
+    assert result["returncode"] == 0
+    assert "1 passed" in result["summary"]


### PR DESCRIPTION
## Summary
- add RegressionSuiteRunner utility for running tests programmatically
- expose RegressionSuiteRunner from ai_workflow package
- extend CLI with `run-regression` command
- document regression suite usage in README
- update module and registry metadata
- record addition in history log
- test RegressionSuiteRunner behavior

## Testing
- `black -q src tests scripts`
- `flake8 src tests scripts` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*