### PR TITLE
Add async workflow scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This repository implements a modern application development workflow optimized f
 - AI-friendly project structure with clear guidance
 - Lightweight workflow orchestration utilities (CLI-driven)
 - Optimized diff analyzer initialization and context graph export
+- Asynchronous scheduler for true parallel task orchestration
 
-### Milestone tags (v0.9 → v1.2)
+### Milestone tags (v0.9 → v1.3)
 
 | Tag | Highlights |
 | --- | ---------- |
@@ -22,6 +23,7 @@ This repository implements a modern application development workflow optimized f
 | v1.0 | Parallel executor and DiffAnalyzer V2 |
 | v1.1 | Context graphs and dashboards |
 | v1.2 | Orchestrator refactor and bug fixes |
+| v1.3 | Async workflow scheduler |
 
 ## Getting Started
 

--- a/src/ai_workflow/__init__.py
+++ b/src/ai_workflow/__init__.py
@@ -6,9 +6,11 @@ Version: 1.0.0
 from .orchestrator import WorkflowOrchestrator
 from .context_graphs import ContextGraphManager
 from .semantic_diff import SemanticDiffAnalyzer
+from .scheduler import WorkflowScheduler
 
 __all__ = [
     "WorkflowOrchestrator",
     "ContextGraphManager",
     "SemanticDiffAnalyzer",
+    "WorkflowScheduler",
 ]

--- a/src/ai_workflow/orchestrator.py
+++ b/src/ai_workflow/orchestrator.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
+import asyncio
 from typing import Any, Dict, List
 
 import yaml
 from concurrent.futures import ThreadPoolExecutor
+
+from .scheduler import WorkflowScheduler
 
 from .context_graphs import ContextGraphManager
 
@@ -23,6 +26,7 @@ class WorkflowOrchestrator:
         """Initialize the orchestrator with registry and budget data."""
 
         self._graph_manager = ContextGraphManager()
+        self._scheduler: WorkflowScheduler | None = None
 
         try:
             with open(registry_path, "r", encoding="utf-8") as f:
@@ -38,6 +42,8 @@ class WorkflowOrchestrator:
             )
         except OSError:
             self._max_parallel = 3
+
+        self._scheduler = WorkflowScheduler(self._max_parallel)
 
     def execute_chain(
         self, chain_name: str, context: Dict[str, Any] | None = None
@@ -124,6 +130,69 @@ class WorkflowOrchestrator:
                 executor.submit(self.execute_module, m, context) for m in modules
             ]
             return [f.result() for f in futures]
+
+    async def execute_module_async(
+        self, module_name: str, context: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Asynchronously execute a single prompt module."""
+
+        return await asyncio.to_thread(self.execute_module, module_name, context)
+
+    async def _run_parallel_async(
+        self, modules: List[str], context: Dict[str, Any] | None = None
+    ) -> List[Dict[str, Any]]:
+        """Execute multiple modules concurrently using the scheduler."""
+
+        assert self._scheduler is not None
+        return await self._scheduler.run_parallel(modules, self.execute_module, context)
+
+    async def execute_chain_async(
+        self, chain_name: str, context: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Asynchronously execute a prompt chain."""
+
+        chain_def = None
+        for chain in self._registry.get("dependencies", []):
+            if chain.get("chain") == chain_name:
+                chain_def = chain
+                break
+
+        if not chain_def:
+            data = {
+                "chain": chain_name,
+                "context": context or {},
+                "status": "executed",
+            }
+            self._graph_manager.update_from_runtime(data)
+            return data
+
+        sequence = chain_def.get("sequence", [])
+        executed: List[Dict[str, Any]] = []
+        i = 0
+        while i < len(sequence):
+            step = sequence[i]
+            if isinstance(step, dict) and "Module_ParallelAsync" in step:
+                modules = step["Module_ParallelAsync"].get("run_parallel", [])
+                executed.extend(await self._run_parallel_async(modules, context))
+                i += 1
+                continue
+
+            if step == "Module_ParallelAsync":
+                modules = sequence[i + 1 : i + 1 + self._max_parallel]
+                executed.extend(await self._run_parallel_async(modules, context))
+                i += 1 + len(modules)
+                continue
+
+            executed.append(await self.execute_module_async(step, context))
+            i += 1
+
+        data = {
+            "chain": chain_name,
+            "executed": [m.get("module") for m in executed],
+            "status": "completed",
+        }
+        self._graph_manager.update_from_runtime(data)
+        return data
 
     def export_context_graph(self, output_dir: str = "audits/dashboards") -> str:
         """Export the context graph and return the file path."""

--- a/src/ai_workflow/scheduler.py
+++ b/src/ai_workflow/scheduler.py
@@ -1,0 +1,30 @@
+"""Async workflow scheduling utilities."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Iterable, List, Callable
+
+
+class WorkflowScheduler:
+    """Run tasks with asynchronous parallelism."""
+
+    def __init__(self, max_parallel: int = 3) -> None:
+        self.max_parallel = max_parallel
+
+    async def run_parallel(
+        self,
+        modules: Iterable[str],
+        run_fn: Callable[[str, Dict[str, Any] | None], Dict[str, Any]],
+        context: Dict[str, Any] | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Execute modules concurrently using an asyncio semaphore."""
+
+        semaphore = asyncio.Semaphore(self.max_parallel)
+
+        async def _run(module: str) -> Dict[str, Any]:
+            async with semaphore:
+                return await asyncio.to_thread(run_fn, module, context)
+
+        tasks = [asyncio.create_task(_run(m)) for m in modules]
+        return await asyncio.gather(*tasks)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from ai_workflow import (
     WorkflowOrchestrator,
     ContextGraphManager,
@@ -58,3 +59,17 @@ def test_performance_monitor(tmp_path):
     assert isinstance(comp, dict)
     for p in dash_files:
         assert os.path.exists(p)
+
+
+@pytest.mark.asyncio
+async def test_async_parallel_chain(tmp_path):
+    orch = WorkflowOrchestrator()
+    result = await orch.execute_chain_async("ParallelFeatureDevCycle", {"foo": "bar"})
+    assert result["status"] == "completed"
+    for mod in [
+        "Module_TaskA",
+        "Module_TestGenerator",
+        "Module_DocWriter",
+        "Module_DiffAnalyzerV2",
+    ]:
+        assert mod in result["executed"]


### PR DESCRIPTION
## Summary
- implement `WorkflowScheduler` for asynchronous parallelism
- extend `WorkflowOrchestrator` with async execution
- export scheduler from `ai_workflow`
- document new capability in README
- add async test coverage

## Testing
- `black -q src/ tests/`
- `flake8 src/ tests/` *(fails: command not found)*
- `pytest` *(fails: command not found)*