### PR TITLE
Add Module_BugFixer and fix cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ The workflow orchestrator reads `execution-budget.yaml` to determine the
 maximum number of parallel threads and spawns them using a lightweight
 scheduler.
 
+### Bug Fix Workflow
+
+Use the BugFixCycle chain to reproduce a bug, apply a fix, and review the change:
+
+```bash
+./scripts/ai_workflow_cli.py execute-chain BugFixCycle --context '{"issue": "BUG-123"}'
+```
+
 ### Analyzing Diffs
 
 To analyze semantic diffs and verify coherence marker compliance:

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -27,3 +27,7 @@
 ## 2025-05-22
 - Expanded `DiffAnalyzerV2` with marker alignment checks and coding standard validation.
 - Updated module documentation and README with new analyzer capabilities.
+
+## 2025-05-23
+- Added dedicated `Module_BugFixer` for handling `[fix]` tasks.
+- Introduced `BugFixCycle` chain and updated prompt registry and README.

--- a/prompt-chains.graphml
+++ b/prompt-chains.graphml
@@ -56,6 +56,14 @@
       <data key="status">active</data>
       <data key="marker">chore</data>
     </node>
+
+    <node id="Module_BugFixer">
+      <data key="name">Module_BugFixer</data>
+      <data key="description">Guides the AI in reproducing and fixing bugs with minimal changes.</data>
+      <data key="version">1.0</data>
+      <data key="status">active</data>
+      <data key="marker">fix</data>
+    </node>
     
     <node id="Module_ParallelAsync">
       <data key="name">Module_ParallelAsync</data>
@@ -130,6 +138,17 @@
     <edge source="Module_RegressionSuite" target="Module_DiffAnalyzerV2">
       <data key="relation">next</data>
       <data key="description">Analyze refactoring changes</data>
+    </edge>
+
+    <!-- BugFixCycle chain -->
+    <edge source="Module_BugFixer" target="Module_TestGenerator">
+      <data key="relation">next</data>
+      <data key="description">Generate tests after applying a bug fix</data>
+    </edge>
+
+    <edge source="Module_TestGenerator" target="Module_DiffAnalyzer">
+      <data key="relation">validate</data>
+      <data key="description">Review the fix with diff analysis</data>
     </edge>
     
     <!-- RefactorCycle chain -->

--- a/prompt-library/module_bug_fixer.v1.md
+++ b/prompt-library/module_bug_fixer.v1.md
@@ -1,0 +1,68 @@
+---
+name: "Module_BugFixer"
+version: "1.0"
+description: "Guides the AI in reproducing and fixing bugs with minimal changes."
+inputs: ["tests/", "src/", "docs/issue_specs/"]
+outputs: ["src/", "tests/"]
+dependencies: ["Module_TestGenerator v1.0"]
+author: "AI"
+last_updated: "2025-05-21"
+status: "active"
+---
+
+# Bug Fix Module
+
+## Purpose
+
+This module instructs the AI in addressing bugs reported via issue tickets or failing tests. It emphasizes reproducing the problem, applying the smallest viable change, and verifying the fix with tests.
+
+## Prompt
+
+You are an AI engineer tasked with fixing a bug in the project. Follow these steps:
+
+1. **Understand the Issue**
+   - Review the issue description or failing test output.
+   - Identify the expected vs actual behavior.
+   - Determine affected components and recent changes.
+
+2. **Reproduce the Bug**
+   - Run the failing test or replicate the steps outlined in the ticket.
+   - Confirm you can reliably trigger the problem.
+
+3. **Isolate the Cause**
+   - Inspect relevant code paths and recent commits.
+   - Narrow down the exact source of the bug.
+
+4. **Apply the Fix**
+   - Make the minimal code change necessary to resolve the issue.
+   - Add comments or docstrings if the fix needs clarification.
+
+5. **Write/Update Tests**
+   - Modify existing tests or create new ones that prove the bug is fixed.
+   - Ensure the test would fail without the fix and pass with it.
+
+6. **Run Tests**
+   - Execute `pytest` to confirm all tests pass.
+   - Address any new failures that arise.
+
+7. **Document the Fix**
+   - Update relevant documentation or issue references.
+   - Summarize what was changed and why.
+
+8. **Generate Commit Message**
+   - Craft a commit message beginning with `[fix]` describing the bug and resolution.
+   - List files changed and reference the issue/ticket number if available.
+
+## Example Output
+
+```markdown
+## Bug Fix: Incorrect Token Expiration
+
+- Reproduced failing test in `tests/auth/test_tokens.py::test_token_expiry`.
+- Cause: Expiration time calculated in minutes instead of seconds.
+- Fixed by adjusting `expiry_seconds` multiplication in `src/auth/tokens.py`.
+- Added regression test `test_token_expiry_correct`.
+- All tests pass (26 total).
+```
+
+<* End of prompt instructions *>

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -39,6 +39,14 @@ modules:
     last_update: "2025-05-20"
     marker: chore
 
+  - name: Module_BugFixer
+    file: prompt-library/module_bug_fixer.v1.md
+    version: 1.0
+    description: Guides the AI in reproducing and fixing bugs with minimal changes.
+    status: active
+    last_update: "2025-05-21"
+    marker: fix
+
   - name: Module_ParallelAsync
     file: modules/03_parallel-async.md
     version: 1.0
@@ -93,13 +101,17 @@ dependencies:
     sequence: ["Module_Observability", "Module_Refactor", "Module_RegressionSuite", "Module_DiffAnalyzerV2"]
     description: "Workflow for identifying and implementing performance improvements."
 
+  - chain: "BugFixCycle"
+    sequence: ["Module_BugFixer", "Module_TestGenerator", "Module_DiffAnalyzer"]
+    description: "Reproduce a bug, apply a minimal fix, generate tests, and review the diff."
+
 categories:
   - name: "feature-development"
     modules: ["Module_TaskA", "Module_TestGenerator"]
     description: "Modules for implementing new features"
     
   - name: "maintenance"
-    modules: ["Module_Refactor", "Module_DiffAnalyzer", "Module_DiffAnalyzerV2"]
+    modules: ["Module_Refactor", "Module_DiffAnalyzer", "Module_DiffAnalyzerV2", "Module_BugFixer"]
     description: "Modules for maintaining and improving existing code"
     
   - name: "documentation"
@@ -117,7 +129,7 @@ markers:
 
   - name: "fix"
     description: "Bug fix"
-    modules: ["Module_TaskA"]
+    modules: ["Module_BugFixer"]
 
   - name: "refactor"
     description: "Code restructuring without behavior change"


### PR DESCRIPTION
## Summary
- create new `Module_BugFixer` prompt module for handling `[fix]` tasks
- link module into `prompt-registry.yaml` and register `BugFixCycle`
- document how to run the new cycle in README
- add new entry in history log
- update prompt chains graph

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: no module named pytest)*