### PR TITLE
Integrate Observability metrics tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ To analyze semantic diffs and verify coherence marker compliance:
 
 ### Monitoring Performance
 
-To update performance metrics and generate dashboards:
+The observability module runs automatically during each chain execution,
+capturing runtime and memory metrics. Use the CLI to update metrics and
+generate dashboards:
 
 ```bash
 # Update metrics for the current iteration

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -31,3 +31,8 @@
 ## 2025-05-23
 - Added dedicated `Module_BugFixer` for handling `[fix]` tasks.
 - Introduced `BugFixCycle` chain and updated prompt registry and README.
+
+## 2025-05-24
+- Upgraded Module_Observability to v1.1 with automatic runtime and memory tracking.
+- Orchestrator now records metrics for each chain execution.
+- Updated README and module documentation accordingly.

--- a/modules/09_observability.md
+++ b/modules/09_observability.md
@@ -1,12 +1,12 @@
 ---
 name: "Module_Observability"
-version: "1.0"
-description: "Monitors and reports performance metrics for Codex Web-Native operations."
+version: "1.1"
+description: "Monitors runtime and memory metrics and validates them against the execution budget."
 inputs: ["audits/performance/", "src/"]
 outputs: ["audits/performance/"]
 dependencies: []
 author: "AI"
-last_updated: "2025-05-20"
+last_updated: "2025-05-24"
 status: "active"
 ---
 
@@ -15,6 +15,10 @@ status: "active"
 ## Purpose
 
 Provide observability into AI task performance, recording metrics such as runtime, memory usage, and responsiveness.
+
+The module now exposes a context manager that measures runtime and memory for each
+workflow iteration and checks the results against the limits defined in
+`execution-budget.yaml`.
 
 ## Prompt
 

--- a/src/ai_workflow/__init__.py
+++ b/src/ai_workflow/__init__.py
@@ -8,6 +8,7 @@ from .context_graphs import ContextGraphManager
 from .semantic_diff import SemanticDiffAnalyzer
 from .scheduler import WorkflowScheduler
 from .diff_analyzer_v2 import DiffAnalyzerV2
+from .performance_monitor import PerformanceMonitor
 
 __all__ = [
     "WorkflowOrchestrator",
@@ -15,4 +16,5 @@ __all__ = [
     "SemanticDiffAnalyzer",
     "WorkflowScheduler",
     "DiffAnalyzerV2",
+    "PerformanceMonitor",
 ]

--- a/src/ai_workflow/performance_monitor.py
+++ b/src/ai_workflow/performance_monitor.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 import os
+import time
+import resource
+from contextlib import contextmanager
 from typing import Any, Dict, List
 
 import yaml
@@ -12,8 +15,8 @@ import yaml
 class PerformanceMonitor:
     """Store and evaluate iteration performance metrics."""
 
-    def __init__(self) -> None:
-        self.metrics_dir = os.path.join("audits", "performance")
+    def __init__(self, metrics_dir: str | None = None) -> None:
+        self.metrics_dir = metrics_dir or os.path.join("audits", "performance")
         os.makedirs(self.metrics_dir, exist_ok=True)
 
         with open("execution-budget.yaml", "r", encoding="utf-8") as f:
@@ -44,7 +47,44 @@ class PerformanceMonitor:
             compliant = False
             violations.append({"metric": "inp_ms", "message": "INP exceeds budget"})
 
+        test_budget = self.budgets.get("test_suite", {})
+        if (
+            "runtime_ms" in metrics
+            and metrics["runtime_ms"]
+            > test_budget.get("max_runtime_seconds", float("inf")) * 1000
+        ):
+            compliant = False
+            violations.append(
+                {"metric": "runtime_ms", "message": "Runtime exceeds budget"}
+            )
+        if "memory_mb" in metrics and metrics["memory_mb"] > test_budget.get(
+            "max_memory_mb", float("inf")
+        ):
+            compliant = False
+            violations.append(
+                {"metric": "memory_mb", "message": "Memory exceeds budget"}
+            )
+
         return {"compliant": compliant, "violations": violations}
+
+    @contextmanager
+    def monitor(self, iteration: str) -> None:
+        """Collect runtime and memory metrics for an iteration."""
+
+        start_time = time.perf_counter()
+        start_mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        try:
+            yield
+        finally:
+            end_time = time.perf_counter()
+            end_mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+            metrics = {
+                "runtime_ms": (end_time - start_time) * 1000,
+                "memory_mb": max(0.0, end_mem - start_mem),
+            }
+            result = self.check_budget_compliance(metrics)
+            metrics.update(result)
+            self.update_iteration_metrics(iteration, metrics)
 
     def generate_performance_dashboard(self) -> List[str]:
         """Create a simple dashboard listing recorded iterations."""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -61,6 +61,19 @@ def test_performance_monitor(tmp_path):
         assert os.path.exists(p)
 
 
+def test_chain_generates_metrics(tmp_path, monkeypatch):
+    import ai_workflow.orchestrator as orch_mod
+
+    def _mon_factory():
+        return PerformanceMonitor(metrics_dir=tmp_path / "audits" / "performance")
+
+    monkeypatch.setattr(orch_mod, "PerformanceMonitor", _mon_factory)
+    orch = WorkflowOrchestrator()
+    orch.execute_chain("demo")
+    metrics_path = tmp_path / "audits" / "performance"
+    assert any(p.suffix == ".json" for p in metrics_path.glob("*.json"))
+
+
 @pytest.mark.asyncio
 async def test_async_parallel_chain(tmp_path):
     orch = WorkflowOrchestrator()


### PR DESCRIPTION
## Summary
- upgrade `Module_Observability` to v1.1 and document runtime tracking
- integrate `PerformanceMonitor` into `WorkflowOrchestrator`
- export `PerformanceMonitor` from `ai_workflow`
- add a test ensuring chain execution records metrics
- update README and history log

## Testing
- `black src/ai_workflow/performance_monitor.py src/ai_workflow/orchestrator.py src/ai_workflow/__init__.py tests/test_workflow.py`
- `flake8 src tests` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*