### PR TITLE
Improve observability metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ To analyze semantic diffs and verify coherence marker compliance:
 ### Monitoring Performance
 
 The observability module runs automatically during each chain execution,
-capturing runtime and memory metrics. Use the CLI to update metrics and
-generate dashboards:
+capturing runtime, memory, and optional UI latency metrics. When metrics exceed
+the limits defined in `execution-budget.yaml`, the PerformanceOptimization chain
+can be invoked to refactor and test affected code automatically. Use the CLI to
+update metrics and generate dashboards:
 
 ```bash
 # Update metrics for the current iteration

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -36,3 +36,8 @@
 - Upgraded Module_Observability to v1.1 with automatic runtime and memory tracking.
 - Orchestrator now records metrics for each chain execution.
 - Updated README and module documentation accordingly.
+
+## 2025-05-25
+- Expanded Module_Observability to v1.2 with UI latency metrics and budget alerts.
+- Updated orchestrator to pass INP, CLS, and TBT values from the execution context.
+- Tests and documentation updated to reflect new observability capabilities.

--- a/modules/09_observability.md
+++ b/modules/09_observability.md
@@ -1,12 +1,12 @@
 ---
 name: "Module_Observability"
-version: "1.1"
-description: "Monitors runtime and memory metrics and validates them against the execution budget."
+version: "1.2"
+description: "Monitors runtime, memory, and UI latency metrics and validates them against the execution budget."
 inputs: ["audits/performance/", "src/"]
 outputs: ["audits/performance/"]
 dependencies: []
 author: "AI"
-last_updated: "2025-05-24"
+last_updated: "2025-05-25"
 status: "active"
 ---
 
@@ -16,10 +16,8 @@ status: "active"
 
 Provide observability into AI task performance, recording metrics such as runtime, memory usage, and responsiveness.
 
-The module now exposes a context manager that measures runtime and memory for each
-workflow iteration and checks the results against the limits defined in
-`execution-budget.yaml`.
+The module exposes a context manager that measures runtime, memory, and optional UI latency metrics for each workflow iteration. Metrics are automatically checked against the limits defined in `execution-budget.yaml`.
 
 ## Prompt
 
-Collect metrics during task execution and update the dashboards under `audits/performance/`. Alert when thresholds defined in `execution-budget.yaml` are exceeded.
+Collect metrics during task execution and update the dashboards under `audits/performance/`. Alert when thresholds defined in `execution-budget.yaml` are exceeded. When violations occur, the PerformanceOptimization chain can be triggered to refactor code and run regression tests automatically.

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -57,10 +57,10 @@ modules:
 
   - name: Module_Observability
     file: modules/09_observability.md
-    version: 1.0
-    description: Monitors and reports performance metrics for Codex Web-Native operations.
+    version: 1.2
+    description: Monitors runtime, memory, and UI latency metrics for Codex Web-Native operations.
     status: active
-    last_update: "2025-05-20"
+    last_update: "2025-05-25"
     marker: chore
 
   - name: Module_RegressionSuite

--- a/src/ai_workflow/orchestrator.py
+++ b/src/ai_workflow/orchestrator.py
@@ -67,7 +67,12 @@ class WorkflowOrchestrator:
         """
 
         iteration = f"{chain_name}_{int(time.time())}"
-        with self._monitor.monitor(iteration):
+        ui_metrics = {
+            k: context[k]
+            for k in ("inp_ms", "cls_ms", "tbt_ms")
+            if context and k in context
+        }
+        with self._monitor.monitor(iteration, ui_metrics or None):
             return self._execute_chain_internal(chain_name, context)
 
     def _execute_chain_internal(
@@ -163,7 +168,12 @@ class WorkflowOrchestrator:
     ) -> Dict[str, Any]:
         """Asynchronously execute a prompt chain."""
         iteration = f"{chain_name}_{int(time.time())}"
-        with self._monitor.monitor(iteration):
+        ui_metrics = {
+            k: context[k]
+            for k in ("inp_ms", "cls_ms", "tbt_ms")
+            if context and k in context
+        }
+        with self._monitor.monitor(iteration, ui_metrics or None):
             return await asyncio.to_thread(
                 self._execute_chain_internal, chain_name, context
             )


### PR DESCRIPTION
## Summary
- track optional UI latency metrics in `PerformanceMonitor`
- pass UI metrics from orchestrator context
- update tests for new observability metrics
- document observability upgrades
- bump Module_Observability to v1.2 and update registry
- log observability changes in history

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*