### PR TITLE
Fix module metadata mismatches

### DIFF
--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -41,3 +41,7 @@
 - Expanded Module_Observability to v1.2 with UI latency metrics and budget alerts.
 - Updated orchestrator to pass INP, CLS, and TBT values from the execution context.
 - Tests and documentation updated to reflect new observability capabilities.
+
+## 2025-05-26
+- Added marker fields to all module front-matter for CI compatibility.
+- Synced Module_DiffAnalyzerV2 metadata in prompt registry.

--- a/modules/03_parallel-async.md
+++ b/modules/03_parallel-async.md
@@ -7,6 +7,7 @@ outputs: ["audits/parallel_execution.log.md"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-20"
+marker: chore
 status: "active"
 ---
 

--- a/modules/09_observability.md
+++ b/modules/09_observability.md
@@ -7,6 +7,7 @@ outputs: ["audits/performance/"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-25"
+marker: chore
 status: "active"
 ---
 

--- a/modules/10_regression-suite.md
+++ b/modules/10_regression-suite.md
@@ -7,6 +7,7 @@ outputs: ["tests/"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-20"
+marker: test
 status: "active"
 ---
 

--- a/modules/11_diff-analyzer.md
+++ b/modules/11_diff-analyzer.md
@@ -7,6 +7,7 @@ outputs: ["audits/diffs/"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-21"
+marker: chore
 status: "active"
 ---
 

--- a/prompt-library/module_bug_fixer.v1.md
+++ b/prompt-library/module_bug_fixer.v1.md
@@ -7,6 +7,7 @@ outputs: ["src/", "tests/"]
 dependencies: ["Module_TestGenerator v1.0"]
 author: "AI"
 last_updated: "2025-05-21"
+marker: fix
 status: "active"
 ---
 

--- a/prompt-library/module_diff_analyzer.v1.md
+++ b/prompt-library/module_diff_analyzer.v1.md
@@ -7,6 +7,7 @@ outputs: ["audits/diffs/"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-20"
+marker: chore
 status: "active"
 ---
 

--- a/prompt-library/module_doc_writer.v1.md
+++ b/prompt-library/module_doc_writer.v1.md
@@ -7,6 +7,7 @@ outputs: ["docs/"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-20"
+marker: docs
 status: "active"
 ---
 

--- a/prompt-library/module_refactor.v1.md
+++ b/prompt-library/module_refactor.v1.md
@@ -7,6 +7,7 @@ outputs: ["src/"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-20"
+marker: refactor
 status: "active"
 ---
 

--- a/prompt-library/module_taskA.v1.md
+++ b/prompt-library/module_taskA.v1.md
@@ -7,6 +7,7 @@ outputs: ["src/", "tests/"]
 dependencies: ["Module_TestGenerator v1.0"]
 author: "AI"
 last_updated: "2025-05-20"
+marker: feat
 status: "active"
 ---
 

--- a/prompt-library/module_test_generator.v1.md
+++ b/prompt-library/module_test_generator.v1.md
@@ -7,6 +7,7 @@ outputs: ["tests/"]
 dependencies: []
 author: "AI"
 last_updated: "2025-05-20"
+marker: test
 status: "active"
 ---
 

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -36,7 +36,7 @@ modules:
     version: 1.0
     description: Analyzes code changes to evaluate impact, quality, and potential issues.
     status: active
-    last_update: "2025-05-20"
+    last_update: "2025-05-21"
     marker: chore
 
   - name: Module_BugFixer
@@ -73,10 +73,10 @@ modules:
 
   - name: Module_DiffAnalyzerV2
     file: modules/11_diff-analyzer.md
-    version: 1.0
+    version: 1.1
     description: Analyzes code changes to ensure coherence marker compliance and perform semantic diff verification.
     status: active
-    last_update: "2025-05-20"
+    last_update: "2025-05-21"
     marker: chore
 
 dependencies:


### PR DESCRIPTION
## Summary
- add `marker` fields to all module front-matter
- update Module_DiffAnalyzerV2 metadata in `prompt-registry.yaml`
- log the update in `audits/history.log.md`

## Testing
- `black . --check`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*