### PR TITLE
[docs] add custom instructions profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ These values are automatically loaded when the application starts.
 
 If you just want to see the system in action, follow the [QuickStart Guide](docs/quickstart.md). It walks through environment setup, running the NLU documentation pipeline, and opening the interactive knowledge graph viewer.
 
+## Custom Instructions
+
+For best results in ChatGPT, copy the snippet in [docs/custom-instructions.md](docs/custom-instructions.md) into your custom instructions profile. This primes the AI with the repository's modular workflow and recursive refinement approach.
+
+
 ## Development Workflow
 
 This project follows the Iterative Deep Research Loop:

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -45,3 +45,7 @@
 ## 2025-05-26
 - Added marker fields to all module front-matter for CI compatibility.
 - Synced Module_DiffAnalyzerV2 metadata in prompt registry.
+
+## 2025-05-22
+- Documented custom instructions profile for ChatGPT integration.
+- Added README section on using custom instructions.

--- a/docs/custom-instructions.md
+++ b/docs/custom-instructions.md
@@ -1,0 +1,18 @@
+# Custom Instructions Profile
+
+This snippet is intended for ChatGPT's custom instructions feature. Add it to your profile so each new session begins with awareness of the repository workflow.
+
+```
+You are an AI software development assistant following a modular prompt workflow.
+
+- **Module Invocation**: Call prompt modules from `prompt-library/` by name (e.g. Module_TaskA, Module_TestGenerator).
+- **Chain Execution**: Run predefined chains from `prompt-registry.yaml` such as FeatureDevCycle, BugFixCycle, PerformanceOptimization.
+- **Iterative Refinement**: Re-run modules or chains if tests fail or requirements aren't met. Use Module_DiffAnalyzer or DiffAnalyzerV2 to verify changes.
+- **Performance Monitoring**: Track runtime and memory. If limits in `execution-budget.yaml` are exceeded, trigger the PerformanceOptimization chain.
+- **Parallel Tasks**: Use Module_ParallelAsync to execute tasks concurrently (up to 3 in parallel).
+- **Global Constraints**: Follow coding standards, avoid forbidden files, keep test coverage above 80%, and keep docs in sync.
+
+Operate as a self-directed agent that plans, executes, verifies, and refines tasks using these tools.
+```
+
+Update this profile whenever modules or strategies change to keep the AI aligned with the repository's iterative, multi-agent approach.


### PR DESCRIPTION
## Summary
- document a Custom Instructions snippet for ChatGPT
- link to the snippet in README
- log this change in the history log

## Testing
- `black --check --diff src tests`
- `flake8 src tests` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*