### PR TITLE
Add merge conflict resolution chain

### DIFF
--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -46,6 +46,10 @@
 - Added marker fields to all module front-matter for CI compatibility.
 - Synced Module_DiffAnalyzerV2 metadata in prompt registry.
 
+## 2025-05-27
+- Introduced `MergeResolutionCycle` for automated merge conflict handling.
+- Added orchestrator helper and updated GitHub integration docs.
+
 ## 2025-05-22
 - Documented custom instructions profile for ChatGPT integration.
 - Added README section on using custom instructions.

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -113,6 +113,19 @@ The `scripts/github_integration.py` utility provides several commands:
 - `pr` - Create a pull request
 - `diff` - Generate a diff report
 
+### Handling Merge Conflicts
+
+When a pull request results in merge conflicts, use the `MergeResolutionCycle`
+workflow to automate resolution and validation:
+
+```bash
+./scripts/ai_workflow_cli.py execute-chain MergeResolutionCycle \
+  --context '{"base_branch": "main"}'
+```
+
+This chain analyzes the conflicting diff, applies fixes, generates tests, and
+updates documentation before performing a final diff review.
+
 ## Branch Protection Rules
 
 Configure the following branch protection rules for the `main` branch:

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -105,6 +105,15 @@ dependencies:
     sequence: ["Module_BugFixer", "Module_TestGenerator", "Module_DiffAnalyzer"]
     description: "Reproduce a bug, apply a minimal fix, generate tests, and review the diff."
 
+  - chain: "MergeResolutionCycle"
+    sequence:
+      - Module_DiffAnalyzer
+      - Module_BugFixer
+      - Module_TestGenerator
+      - Module_DocWriter
+      - Module_DiffAnalyzerV2
+    description: "Resolve merge conflicts and verify code/doc integrity."
+
 categories:
   - name: "feature-development"
     modules: ["Module_TaskA", "Module_TestGenerator"]

--- a/src/ai_workflow/orchestrator.py
+++ b/src/ai_workflow/orchestrator.py
@@ -75,6 +75,13 @@ class WorkflowOrchestrator:
         with self._monitor.monitor(iteration, ui_metrics or None):
             return self._execute_chain_internal(chain_name, context)
 
+    def resolve_merge_conflicts(
+        self, context: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Run the MergeResolutionCycle chain."""
+
+        return self.execute_chain("MergeResolutionCycle", context)
+
     def _execute_chain_internal(
         self, chain_name: str, context: Dict[str, Any] | None = None
     ) -> Dict[str, Any]:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -82,6 +82,20 @@ def test_chain_generates_metrics(tmp_path, monkeypatch):
         assert "inp_ms" in data and "tbt_ms" in data and "cls_ms" in data
 
 
+def test_merge_resolution_cycle():
+    orch = WorkflowOrchestrator()
+    result = orch.resolve_merge_conflicts({"foo": "bar"})
+    assert result["status"] == "completed"
+    for mod in [
+        "Module_DiffAnalyzer",
+        "Module_BugFixer",
+        "Module_TestGenerator",
+        "Module_DocWriter",
+        "Module_DiffAnalyzerV2",
+    ]:
+        assert mod in result["executed"]
+
+
 @pytest.mark.asyncio
 async def test_async_parallel_chain(tmp_path):
     orch = WorkflowOrchestrator()


### PR DESCRIPTION
## Summary
- define `MergeResolutionCycle` chain for automated merge conflict handling
- expose `resolve_merge_conflicts()` helper in the orchestrator
- document merge resolution workflow
- log workflow addition in history
- test new chain invocation

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*