### PR TITLE
Restore merge conflict workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ These values are automatically loaded when the application starts.
 
 If you just want to see the system in action, follow the [QuickStart Guide](docs/quickstart.md). It walks through environment setup, running the NLU documentation pipeline, and opening the interactive knowledge graph viewer.
 
+## Custom Instructions
+
+For best results in ChatGPT, copy the snippet in [docs/custom-instructions.md](docs/custom-instructions.md) into your custom instructions profile. This primes the AI with the repository's modular workflow and recursive refinement approach.
+
+
 ## Development Workflow
 
 This project follows the Iterative Deep Research Loop:

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -45,3 +45,11 @@
 ## 2025-05-26
 - Added marker fields to all module front-matter for CI compatibility.
 - Synced Module_DiffAnalyzerV2 metadata in prompt registry.
+
+## 2025-05-27
+- Restored `resolve_merge_conflicts` method with helper integration.
+- Added `MergeResolutionCycle` chain and documentation.
+
+## 2025-05-22
+- Documented custom instructions profile for ChatGPT integration.
+- Added README section on using custom instructions.

--- a/docs/custom-instructions.md
+++ b/docs/custom-instructions.md
@@ -1,0 +1,18 @@
+# Custom Instructions Profile
+
+This snippet is intended for ChatGPT's custom instructions feature. Add it to your profile so each new session begins with awareness of the repository workflow.
+
+```
+You are an AI software development assistant following a modular prompt workflow.
+
+- **Module Invocation**: Call prompt modules from `prompt-library/` by name (e.g. Module_TaskA, Module_TestGenerator).
+- **Chain Execution**: Run predefined chains from `prompt-registry.yaml` such as FeatureDevCycle, BugFixCycle, PerformanceOptimization.
+- **Iterative Refinement**: Re-run modules or chains if tests fail or requirements aren't met. Use Module_DiffAnalyzer or DiffAnalyzerV2 to verify changes.
+- **Performance Monitoring**: Track runtime and memory. If limits in `execution-budget.yaml` are exceeded, trigger the PerformanceOptimization chain.
+- **Parallel Tasks**: Use Module_ParallelAsync to execute tasks concurrently (up to 3 in parallel).
+- **Global Constraints**: Follow coding standards, avoid forbidden files, keep test coverage above 80%, and keep docs in sync.
+
+Operate as a self-directed agent that plans, executes, verifies, and refines tasks using these tools.
+```
+
+Update this profile whenever modules or strategies change to keep the AI aligned with the repository's iterative, multi-agent approach.

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -157,3 +157,13 @@ Configure the following branch protection rules for the `main` branch:
    - Update the history log when making significant changes
 
 By following these guidelines, you'll ensure smooth collaboration and maintain the integrity of the Codex Web-Native framework.
+
+## Handling Merge Conflicts
+
+When pull requests cannot be merged automatically, run the `MergeResolutionCycle` chain to address conflicts:
+
+```bash
+./scripts/ai_workflow_cli.py execute-chain MergeResolutionCycle
+```
+
+The cycle attempts to resolve conflict markers in `README.md` and `audits/history.log.md`, applies fixes, regenerates tests, and validates the result with `DiffAnalyzerV2`.

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -105,6 +105,15 @@ dependencies:
     sequence: ["Module_BugFixer", "Module_TestGenerator", "Module_DiffAnalyzer"]
     description: "Reproduce a bug, apply a minimal fix, generate tests, and review the diff."
 
+  - chain: "MergeResolutionCycle"
+    sequence:
+      - "Module_DiffAnalyzer"
+      - "Module_BugFixer"
+      - "Module_TestGenerator"
+      - "Module_DocWriter"
+      - "Module_DiffAnalyzerV2"
+    description: "Resolve merge conflicts and verify code/doc integrity."
+
 categories:
   - name: "feature-development"
     modules: ["Module_TaskA", "Module_TestGenerator"]

--- a/src/ai_workflow/orchestrator.py
+++ b/src/ai_workflow/orchestrator.py
@@ -184,3 +184,24 @@ class WorkflowOrchestrator:
         os.makedirs(output_dir, exist_ok=True)
         output_path = os.path.join(output_dir, "context_graph.html")
         return self._graph_manager.generate_html_visualization(output_path)
+
+    def resolve_merge_conflicts(
+        self, context: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Resolve merge conflicts then run the MergeResolutionCycle chain."""
+
+        from utils.merge_helper import auto_merge_conflict_blocks
+
+        files = ["README.md", "audits/history.log.md"]
+        for file in files:
+            try:
+                with open(file, "r", encoding="utf-8") as f:
+                    content = f.read()
+                if "<<<<" in content:
+                    merged = auto_merge_conflict_blocks(content)
+                    with open(file, "w", encoding="utf-8") as f:
+                        f.write(merged)
+            except OSError:
+                continue
+
+        return self.execute_chain("MergeResolutionCycle", context)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for the Codex Web-Native system."""

--- a/src/utils/merge_helper.py
+++ b/src/utils/merge_helper.py
@@ -1,0 +1,19 @@
+"""Helpers for resolving git merge conflicts."""
+
+from __future__ import annotations
+
+import re
+
+
+def auto_merge_conflict_blocks(content: str) -> str:
+    """Auto-resolve simple conflict blocks by taking the incoming changes."""
+
+    pattern = re.compile(
+        r"<<<<<<<[^\n]*\n(?P<head>.*?)\n=======\n(?P<incoming>.*?)\n>>>>>>>[^\n]*\n",
+        re.DOTALL,
+    )
+
+    def _choose(match: re.Match[str]) -> str:
+        return match.group("incoming")
+
+    return re.sub(pattern, _choose, content)

--- a/tests/test_merge_helper.py
+++ b/tests/test_merge_helper.py
@@ -1,0 +1,35 @@
+from src.ai_workflow.orchestrator import WorkflowOrchestrator
+from utils.merge_helper import auto_merge_conflict_blocks
+import os
+
+
+def test_auto_merge_conflict_blocks():
+    content = """<<<<<<< HEAD
+ours
+=======
+theirs
+>>>>>>> main
+"""
+    result = auto_merge_conflict_blocks(content)
+    assert result.strip() == "theirs"
+
+
+def test_orchestrator_resolve_merge_conflicts(tmp_path, monkeypatch):
+    readme = tmp_path / "README.md"
+    log = tmp_path / "audits" / "history.log.md"
+    log.parent.mkdir()
+    readme.write_text(
+        """<<<<<<< HEAD\nold\n=======\nnew\n>>>>>>> branch\n""",
+        encoding="utf-8",
+    )
+    log.write_text(
+        """<<<<<<< HEAD\na\n=======\nb\n>>>>>>> branch\n""",
+        encoding="utf-8",
+    )
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    orch = WorkflowOrchestrator()
+    orch.resolve_merge_conflicts()
+    os.chdir(cwd)
+    assert readme.read_text().strip() == "new"
+    assert log.read_text().strip() == "b"


### PR DESCRIPTION
## Summary
- re-add `resolve_merge_conflicts` method with helper integration
- create `merge_helper` util for auto merging conflict blocks
- register `MergeResolutionCycle` chain
- document how to run it in GitHub integration guide
- log the change in `history.log`
- add tests for helper and orchestrator method

## Testing
- `black --check src tests`
- `flake8 src tests` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*