### PR TITLE
Update merge cycle marker and registry version

### DIFF
--- a/ai_workflow/__init__.py
+++ b/ai_workflow/__init__.py
@@ -1,0 +1,22 @@
+from importlib import import_module
+
+_base = import_module("src.ai_workflow")
+for attr in _base.__all__:
+    globals()[attr] = getattr(_base, attr)
+
+# Expose submodules for fully-qualified imports
+submodules = [
+    "orchestrator",
+    "context_graphs",
+    "semantic_diff",
+    "scheduler",
+    "diff_analyzer_v2",
+    "performance_monitor",
+]
+for name in submodules:
+    module = import_module(f"src.ai_workflow.{name}")
+    globals()[name] = module
+    import_module = __import__  # to use same name
+    import sys
+
+    sys.modules[f"{__name__}.{name}"] = module

--- a/audits/history.log.md
+++ b/audits/history.log.md
@@ -50,6 +50,12 @@
 - Introduced `MergeResolutionCycle` for automated merge conflict handling.
 - Added orchestrator helper and updated GitHub integration docs.
 
+## 2025-05-28
+- Added `marker` field to `MergeResolutionCycle` and bumped prompt registry to v1.4.1.
+
+## 2025-05-29
+- Added YAML front-matter to custom instructions doc for docs pipeline compliance.
+
 ## 2025-05-22
 - Documented custom instructions profile for ChatGPT integration.
 - Added README section on using custom instructions.

--- a/docs/custom-instructions.md
+++ b/docs/custom-instructions.md
@@ -1,3 +1,10 @@
+---
+title: "Custom Instructions Profile"
+description: "Snippet to prime ChatGPT Codex with the MGWXP modular workflow."
+last_updated: "2025-05-29"
+docs_category: "getting-started"
+---
+
 # Custom Instructions Profile
 
 This snippet is intended for ChatGPT's custom instructions feature. Add it to your profile so each new session begins with awareness of the repository workflow.

--- a/prompt-registry.yaml
+++ b/prompt-registry.yaml
@@ -113,6 +113,7 @@ dependencies:
       - Module_DocWriter
       - Module_DiffAnalyzerV2
     description: "Resolve merge conflicts and verify code/doc integrity."
+    marker: "chore"
 
 categories:
   - name: "feature-development"
@@ -163,3 +164,5 @@ markers:
   - name: "perf"
     description: "Performance improvements"
     modules: ["Module_Refactor"]
+
+version: "1.4.1"


### PR DESCRIPTION
## Summary
- fix MergeResolutionCycle metadata to include a `chore` marker
- bump prompt-registry version to 1.4.1
- allow `ai_workflow` imports via compatibility module
- record update in history log

## Testing
- `black . --check`
- `flake8`
- `PYTHONPATH=$PWD pytest -q`
